### PR TITLE
Slim down navigation bar while keeping logo prominent

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,8 @@
     .nav {
       max-width: 1200px;
       margin: 0 auto;
-      padding: 0.15rem 2rem;
+      padding: 0.35rem 2rem;
+      min-height: 4.5rem;
       display: grid;
       grid-template-columns: 1fr auto 1fr;
       align-items: center;
@@ -57,18 +58,25 @@
     }
 
     .logo {
+      position: relative;
       display: flex;
       align-items: center;
+      justify-content: center;
       grid-column: 2;
       justify-self: center;
       text-decoration: none;
       color: var(--text);
       font-weight: 700;
       letter-spacing: 0.04em;
-      gap: 1rem;
+      height: 4.5rem;
+      width: 150px;
     }
 
     .logo img {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
       width: 150px;
       height: 150px;
       object-fit: contain;
@@ -582,7 +590,12 @@
 
     @media (max-width: 600px) {
       .nav {
-        padding: 0.75rem 1.4rem;
+        padding: 0.5rem 1.4rem;
+        min-height: 4rem;
+      }
+
+      .logo {
+        height: 4rem;
       }
 
       section {


### PR DESCRIPTION
## Summary
- tighten the navigation bar padding and set a minimum height so the header appears slimmer
- reposition the logo image absolutely within a fixed-height anchor so the logo size stays unchanged while the bar shrinks
- adjust the mobile breakpoint styling to keep the compact header sizing on small screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3c03c174c8330a638aa603b450636