### PR TITLE
Center navigation links relative to logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,12 +85,22 @@
 
     .nav-left {
       grid-column: 1;
-      justify-self: start;
+      justify-self: stretch;
+      display: flex;
+      justify-content: center;
     }
 
     .nav-right {
       grid-column: 3;
-      justify-self: end;
+      justify-self: stretch;
+      display: flex;
+      justify-content: center;
+    }
+
+    .nav-left ul,
+    .nav-right ul {
+      justify-content: center;
+      width: 100%;
     }
 
     nav ul {


### PR DESCRIPTION
## Summary
- center the left and right navigation groups within their grid columns so the header links sit evenly between the logo and the viewport edges

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e4b2fee2808330ad4575d8c477ff38